### PR TITLE
Update sprockets-es6 dependency

### DIFF
--- a/foundation-rails.gemspec
+++ b/foundation-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sass", [">= 3.3.0", "< 3.5"]
   spec.add_dependency "railties", [">= 3.1.0"]
-  spec.add_dependency "sprockets-es6", [">= 0.9.0"]
+  spec.add_dependency "sprockets-es6", [">= 0.9.1"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "capybara"


### PR DESCRIPTION
sprockets-es6 0.9.1 removes a ton of depreciation notices when using the current version of rails and sprockets.

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
```

See https://github.com/TannerRogalsky/sprockets-es6/commit/fb498189d7d8b8a0bf19c215368265dadb443a99 for more details.
